### PR TITLE
Add support for proxy mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Usage of wg-nc:
         Port to listen on or connect to (prepended by colon), i.e. :9999 (default ":9999")
   -proto string
         TCP/UDP mode (default "tcp")
+  -proxy-port string
+        Port to listen for connections to proxy, i.e :9999.
   -wg string
         Wireguard config file
 ```
@@ -26,4 +28,6 @@ Usage of wg-nc:
 Comments:
 
 * Send `~.` to disconnect in UDP mode.
+* Proxy mode (when `-proxy-port` is provided) ignores process stdout and stdin and instead setups a persistent server, which forwards
+  requests to the provided host + port.
 * Wireguard support was inspired by the [Our User-Mode WireGuard Year](https://fly.io/blog/our-user-mode-wireguard-year/) blog post.


### PR DESCRIPTION
In a normal `nc` a persistent proxy will look something like:
```
nc -lk -p 6000 -e nc <target> <target-port>
```
This works for `wg-nc` as well, but it has the downside that wireguard connections are negotiated every time and parallel wireguard connections with their own states, but shared credentials are a no-go.

To solve this, we introduce an all-in-one proxy mode, which listens and establish connections over single wireguard (user land) connection.